### PR TITLE
chore: import repository https://github.com/alfredodeza/jx-python-http.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: SourceConfig
+metadata:
+  creationTimestamp: null
+spec:
+  groups:
+  - owner: alfredodeza
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: jx-python-http
+    scheduler: in-repo
+  slack:
+    channel: '#jenkins-x-pipelines'
+    kind: failureOrNextSuccess
+    pipeline: release


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/docs/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
